### PR TITLE
Change type CAFElement to type Command

### DIFF
--- a/dist/caf-ranks.json
+++ b/dist/caf-ranks.json
@@ -1,5 +1,5 @@
 {
-    "element": {
+    "command": {
         "CA": { "en": "Canadian Army", "fr": "Armée canadienne" },
         "RCAF": {
             "en": "Royal Canadian Air Force",
@@ -30,7 +30,7 @@
     "allRanks": [
         {
             "level": 19,
-            "element": ["CA", "RCAF"],
+            "commands": ["CA", "RCAF"],
             "title": {
                 "en": "General",
                 "fr": "Général"
@@ -43,7 +43,7 @@
         },
         {
             "level": 19,
-            "element": ["RCN"],
+            "commands": ["RCN"],
             "title": {
                 "en": "Admiral",
                 "fr": "Amiral"
@@ -56,7 +56,7 @@
         },
         {
             "level": 18,
-            "element": ["CA", "RCAF"],
+            "commands": ["CA", "RCAF"],
             "title": {
                 "en": "Lieutenant-General",
                 "fr": "Lieutenant-général"
@@ -69,7 +69,7 @@
         },
         {
             "level": 18,
-            "element": ["RCN"],
+            "commands": ["RCN"],
             "title": {
                 "en": "Vice-Admiral",
                 "fr": "Vice-amiral"
@@ -82,7 +82,7 @@
         },
         {
             "level": 17,
-            "element": ["CA", "RCAF"],
+            "commands": ["CA", "RCAF"],
             "title": {
                 "en": "Major-General",
                 "fr": "Major-général"
@@ -95,7 +95,7 @@
         },
         {
             "level": 17,
-            "element": ["RCN"],
+            "commands": ["RCN"],
             "title": {
                 "en": "Rear-Admiral",
                 "fr": "Contre-amiral"
@@ -108,7 +108,7 @@
         },
         {
             "level": 16,
-            "element": ["CA", "RCAF"],
+            "commands": ["CA", "RCAF"],
             "title": {
                 "en": "Brigadier-General",
                 "fr": "Brigadier-général"
@@ -121,7 +121,7 @@
         },
         {
             "level": 16,
-            "element": ["RCN"],
+            "commands": ["RCN"],
             "title": {
                 "en": "Commodore",
                 "fr": "Commodore"
@@ -134,7 +134,7 @@
         },
         {
             "level": 15,
-            "element": ["CA", "RCAF"],
+            "commands": ["CA", "RCAF"],
             "title": {
                 "en": "Colonel",
                 "fr": "Colonel"
@@ -147,7 +147,7 @@
         },
         {
             "level": 15,
-            "element": ["RCN"],
+            "commands": ["RCN"],
             "title": {
                 "en": "Captain(N)",
                 "fr": "Capitaine de vaisseau"
@@ -160,7 +160,7 @@
         },
         {
             "level": 14,
-            "element": ["CA", "RCAF"],
+            "commands": ["CA", "RCAF"],
             "title": {
                 "en": "Lieutenant-Colonel",
                 "fr": "Lieutenant-colonel"
@@ -173,7 +173,7 @@
         },
         {
             "level": 14,
-            "element": ["RCN"],
+            "commands": ["RCN"],
             "title": {
                 "en": "Commander",
                 "fr": "Capitaine de frégate"
@@ -186,7 +186,7 @@
         },
         {
             "level": 13,
-            "element": ["CA", "RCAF"],
+            "commands": ["CA", "RCAF"],
             "title": {
                 "en": "Major",
                 "fr": "Major"
@@ -199,7 +199,7 @@
         },
         {
             "level": 13,
-            "element": ["RCN"],
+            "commands": ["RCN"],
             "title": {
                 "en": "Lieutenant-Commander",
                 "fr": "Capitaine de corvette"
@@ -212,7 +212,7 @@
         },
         {
             "level": 12,
-            "element": ["CA", "RCAF"],
+            "commands": ["CA", "RCAF"],
             "title": {
                 "en": "Captain",
                 "fr": "Capitaine"
@@ -225,7 +225,7 @@
         },
         {
             "level": 12,
-            "element": ["RCN"],
+            "commands": ["RCN"],
             "title": {
                 "en": "Lieutenant(N)",
                 "fr": "Lieutenant de vaisseau"
@@ -238,7 +238,7 @@
         },
         {
             "level": 11,
-            "element": ["CA", "RCAF"],
+            "commands": ["CA", "RCAF"],
             "title": {
                 "en": "Lieutenant",
                 "fr": "Lieutenant"
@@ -251,7 +251,7 @@
         },
         {
             "level": 11,
-            "element": ["RCN"],
+            "commands": ["RCN"],
             "title": {
                 "en": "Sub-Lieutenant",
                 "fr": "Enseigne de vaisseau de 1re classe"
@@ -264,7 +264,7 @@
         },
         {
             "level": 10,
-            "element": ["CA", "RCAF"],
+            "commands": ["CA", "RCAF"],
             "title": {
                 "en": "Second Lieutenant",
                 "fr": "Sous-lieutenant"
@@ -277,7 +277,7 @@
         },
         {
             "level": 10,
-            "element": ["RCN"],
+            "commands": ["RCN"],
             "title": {
                 "en": "Acting Sub-Lieutenant",
                 "fr": "Enseigne de vaisseau de 2e classe"
@@ -290,7 +290,7 @@
         },
         {
             "level": 9,
-            "element": ["CA", "RCAF"],
+            "commands": ["CA", "RCAF"],
             "title": {
                 "en": "Officer Cadet",
                 "fr": "Élève-officier"
@@ -303,7 +303,7 @@
         },
         {
             "level": 9,
-            "element": ["RCN"],
+            "commands": ["RCN"],
             "title": {
                 "en": "Naval Cadet",
                 "fr": "Aspirant de marine"
@@ -316,7 +316,7 @@
         },
         {
             "level": 8,
-            "element": ["CA", "RCAF"],
+            "commands": ["CA", "RCAF"],
             "title": {
                 "en": "Chief Warrant Officer",
                 "fr": "Adjudant-chef"
@@ -329,7 +329,7 @@
         },
         {
             "level": 8,
-            "element": ["RCN"],
+            "commands": ["RCN"],
             "title": {
                 "en": "Chief Petty Officer 1st class",
                 "fr": "Premier maître de 1re classe"
@@ -342,7 +342,7 @@
         },
         {
             "level": 7,
-            "element": ["CA", "RCAF"],
+            "commands": ["CA", "RCAF"],
             "title": {
                 "en": "Master Warrant Officer",
                 "fr": "Adjudant-maître"
@@ -355,7 +355,7 @@
         },
         {
             "level": 7,
-            "element": ["RCN"],
+            "commands": ["RCN"],
             "title": {
                 "en": "Chief Petty Officer 2nd class",
                 "fr": "Premier maître de 2e classe"
@@ -368,7 +368,7 @@
         },
         {
             "level": 6,
-            "element": ["CA", "RCAF"],
+            "commands": ["CA", "RCAF"],
             "title": {
                 "en": "Warrant Officer",
                 "fr": "Adjudant"
@@ -381,7 +381,7 @@
         },
         {
             "level": 6,
-            "element": ["RCN"],
+            "commands": ["RCN"],
             "title": {
                 "en": "Petty Officer 1st class",
                 "fr": "Maître de 1re classe"
@@ -394,7 +394,7 @@
         },
         {
             "level": 5,
-            "element": ["CA", "RCAF"],
+            "commands": ["CA", "RCAF"],
             "title": {
                 "en": "Sergeant",
                 "fr": "Sergent"
@@ -407,7 +407,7 @@
         },
         {
             "level": 5,
-            "element": ["RCN"],
+            "commands": ["RCN"],
             "title": {
                 "en": "Petty Officer 2nd class",
                 "fr": "Maître de 2e classe"
@@ -420,7 +420,7 @@
         },
         {
             "level": 4,
-            "element": ["CA", "RCAF"],
+            "commands": ["CA", "RCAF"],
             "title": {
                 "en": "Master Corporal",
                 "fr": "Caporal-chef"
@@ -433,7 +433,7 @@
         },
         {
             "level": 4,
-            "element": ["RCN"],
+            "commands": ["RCN"],
             "title": {
                 "en": "Master Sailor",
                 "fr": "Matelot-chef"
@@ -446,7 +446,7 @@
         },
         {
             "level": 3,
-            "element": ["CA", "RCAF"],
+            "commands": ["CA", "RCAF"],
             "title": {
                 "en": "Corporal",
                 "fr": "Caporal"
@@ -459,7 +459,7 @@
         },
         {
             "level": 3,
-            "element": ["RCN"],
+            "commands": ["RCN"],
             "title": {
                 "en": "Sailor 1st Class",
                 "fr": "Matelot de 1re classe"
@@ -472,7 +472,7 @@
         },
         {
             "level": 2,
-            "element": ["CA"],
+            "commands": ["CA"],
             "title": {
                 "en": "Private (Trained)",
                 "fr": "Soldat (formé)"
@@ -485,7 +485,7 @@
         },
         {
             "level": 2,
-            "element": ["RCAF"],
+            "commands": ["RCAF"],
             "title": {
                 "en": "Aviator (Trained)",
                 "fr": "Aviateur (formé)"
@@ -498,7 +498,7 @@
         },
         {
             "level": 2,
-            "element": ["RCN"],
+            "commands": ["RCN"],
             "title": {
                 "en": "Sailor 2nd Class",
                 "fr": "Matelot de 2e classe"
@@ -511,7 +511,7 @@
         },
         {
             "level": 1,
-            "element": ["CA"],
+            "commands": ["CA"],
             "title": {
                 "en": "Private (Basic)",
                 "fr": "Soldat (confirmé)"
@@ -524,7 +524,7 @@
         },
         {
             "level": 1,
-            "element": ["RCAF"],
+            "commands": ["RCAF"],
             "title": {
                 "en": "Aviator (Basic)",
                 "fr": "Aviateur (confirmé)"
@@ -537,7 +537,7 @@
         },
         {
             "level": 1,
-            "element": ["RCN"],
+            "commands": ["RCN"],
             "title": {
                 "en": "Sailor 3rd Class",
                 "fr": "Matelot de 3e classe"

--- a/dist/main.d.ts
+++ b/dist/main.d.ts
@@ -2,10 +2,10 @@ export type BilingualString = {
     en: string;
     fr: string;
 };
-export type CAFElement = "CA" | "RCAF" | "RCN";
+export type Command = "CA" | "RCAF" | "RCN";
 export type RankCategory = "FlagOfficer" | "SeniorOfficer" | "JuniorOfficer" | "SubordinateOfficer" | "SeniorNCO" | "JuniorNCM";
 export type RankMeta = {
-    element: {
+    command: {
         CA: BilingualString;
         RCAF: BilingualString;
         RCN: BilingualString;
@@ -21,7 +21,7 @@ export type RankMeta = {
 };
 export type Rank = {
     level: number;
-    element: CAFElement[];
+    commands: Command[];
     title: BilingualString;
     abbreviation: BilingualString;
     category: RankCategory;
@@ -29,7 +29,7 @@ export type Rank = {
 };
 export declare const rankMeta: RankMeta;
 export declare const allRanks: Rank[];
-export declare function filterRanksByElement(ranks: Rank[], cafElement: CAFElement): Rank[];
+export declare function filterRanksByElement(ranks: Rank[], command: Command): Rank[];
 export declare function filterRanksByCategory(ranks: Rank[], rankCategory: RankCategory): Rank[];
 declare const _default: {
     rankMeta: RankMeta;

--- a/dist/main.js
+++ b/dist/main.js
@@ -8,15 +8,15 @@ exports.filterRanksByElement = filterRanksByElement;
 exports.filterRanksByCategory = filterRanksByCategory;
 const caf_ranks_json_1 = __importDefault(require("./caf-ranks.json"));
 exports.rankMeta = {
-    element: caf_ranks_json_1.default.element,
+    command: caf_ranks_json_1.default.command,
     category: caf_ranks_json_1.default.category,
 };
-exports.allRanks = caf_ranks_json_1.default.allRanks.map((rank) => (Object.assign(Object.assign({}, rank), { element: rank.element, category: rank.category, getCategoryName: function () {
+exports.allRanks = caf_ranks_json_1.default.allRanks.map((rank) => (Object.assign(Object.assign({}, rank), { commands: rank.commands, category: rank.category, getCategoryName: function () {
         return exports.rankMeta.category[this.category];
     } })));
-function filterRanksByElement(ranks, cafElement) {
+function filterRanksByElement(ranks, command) {
     return ranks.filter((rank) => {
-        return rank.element.filter((element) => element === cafElement).length > 0;
+        return rank.commands.filter((_command) => _command === command).length > 0;
     });
 }
 function filterRanksByCategory(ranks, rankCategory) {

--- a/src/caf-ranks.json
+++ b/src/caf-ranks.json
@@ -1,5 +1,5 @@
 {
-  "element": {
+  "command": {
     "CA": { "en": "Canadian Army", "fr": "Armée canadienne" },
     "RCAF": {
       "en": "Royal Canadian Air Force",
@@ -30,7 +30,7 @@
   "allRanks": [
     {
       "level": 19,
-      "element": ["CA", "RCAF"],
+      "commands": ["CA", "RCAF"],
       "title": {
         "en": "General",
         "fr": "Général"
@@ -43,7 +43,7 @@
     },
     {
       "level": 19,
-      "element": ["RCN"],
+      "commands": ["RCN"],
       "title": {
         "en": "Admiral",
         "fr": "Amiral"
@@ -56,7 +56,7 @@
     },
     {
       "level": 18,
-      "element": ["CA", "RCAF"],
+      "commands": ["CA", "RCAF"],
       "title": {
         "en": "Lieutenant-General",
         "fr": "Lieutenant-général"
@@ -69,7 +69,7 @@
     },
     {
       "level": 18,
-      "element": ["RCN"],
+      "commands": ["RCN"],
       "title": {
         "en": "Vice-Admiral",
         "fr": "Vice-amiral"
@@ -82,7 +82,7 @@
     },
     {
       "level": 17,
-      "element": ["CA", "RCAF"],
+      "commands": ["CA", "RCAF"],
       "title": {
         "en": "Major-General",
         "fr": "Major-général"
@@ -95,7 +95,7 @@
     },
     {
       "level": 17,
-      "element": ["RCN"],
+      "commands": ["RCN"],
       "title": {
         "en": "Rear-Admiral",
         "fr": "Contre-amiral"
@@ -108,7 +108,7 @@
     },
     {
       "level": 16,
-      "element": ["CA", "RCAF"],
+      "commands": ["CA", "RCAF"],
       "title": {
         "en": "Brigadier-General",
         "fr": "Brigadier-général"
@@ -121,7 +121,7 @@
     },
     {
       "level": 16,
-      "element": ["RCN"],
+      "commands": ["RCN"],
       "title": {
         "en": "Commodore",
         "fr": "Commodore"
@@ -134,7 +134,7 @@
     },
     {
       "level": 15,
-      "element": ["CA", "RCAF"],
+      "commands": ["CA", "RCAF"],
       "title": {
         "en": "Colonel",
         "fr": "Colonel"
@@ -147,7 +147,7 @@
     },
     {
       "level": 15,
-      "element": ["RCN"],
+      "commands": ["RCN"],
       "title": {
         "en": "Captain(N)",
         "fr": "Capitaine de vaisseau"
@@ -160,7 +160,7 @@
     },
     {
       "level": 14,
-      "element": ["CA", "RCAF"],
+      "commands": ["CA", "RCAF"],
       "title": {
         "en": "Lieutenant-Colonel",
         "fr": "Lieutenant-colonel"
@@ -173,7 +173,7 @@
     },
     {
       "level": 14,
-      "element": ["RCN"],
+      "commands": ["RCN"],
       "title": {
         "en": "Commander",
         "fr": "Capitaine de frégate"
@@ -186,7 +186,7 @@
     },
     {
       "level": 13,
-      "element": ["CA", "RCAF"],
+      "commands": ["CA", "RCAF"],
       "title": {
         "en": "Major",
         "fr": "Major"
@@ -199,7 +199,7 @@
     },
     {
       "level": 13,
-      "element": ["RCN"],
+      "commands": ["RCN"],
       "title": {
         "en": "Lieutenant-Commander",
         "fr": "Capitaine de corvette"
@@ -212,7 +212,7 @@
     },
     {
       "level": 12,
-      "element": ["CA", "RCAF"],
+      "commands": ["CA", "RCAF"],
       "title": {
         "en": "Captain",
         "fr": "Capitaine"
@@ -225,7 +225,7 @@
     },
     {
       "level": 12,
-      "element": ["RCN"],
+      "commands": ["RCN"],
       "title": {
         "en": "Lieutenant(N)",
         "fr": "Lieutenant de vaisseau"
@@ -238,7 +238,7 @@
     },
     {
       "level": 11,
-      "element": ["CA", "RCAF"],
+      "commands": ["CA", "RCAF"],
       "title": {
         "en": "Lieutenant",
         "fr": "Lieutenant"
@@ -251,7 +251,7 @@
     },
     {
       "level": 11,
-      "element": ["RCN"],
+      "commands": ["RCN"],
       "title": {
         "en": "Sub-Lieutenant",
         "fr": "Enseigne de vaisseau de 1re classe"
@@ -264,7 +264,7 @@
     },
     {
       "level": 10,
-      "element": ["CA", "RCAF"],
+      "commands": ["CA", "RCAF"],
       "title": {
         "en": "Second Lieutenant",
         "fr": "Sous-lieutenant"
@@ -277,7 +277,7 @@
     },
     {
       "level": 10,
-      "element": ["RCN"],
+      "commands": ["RCN"],
       "title": {
         "en": "Acting Sub-Lieutenant",
         "fr": "Enseigne de vaisseau de 2e classe"
@@ -290,7 +290,7 @@
     },
     {
       "level": 9,
-      "element": ["CA", "RCAF"],
+      "commands": ["CA", "RCAF"],
       "title": {
         "en": "Officer Cadet",
         "fr": "Élève-officier"
@@ -303,7 +303,7 @@
     },
     {
       "level": 9,
-      "element": ["RCN"],
+      "commands": ["RCN"],
       "title": {
         "en": "Naval Cadet",
         "fr": "Aspirant de marine"
@@ -316,7 +316,7 @@
     },
     {
       "level": 8,
-      "element": ["CA", "RCAF"],
+      "commands": ["CA", "RCAF"],
       "title": {
         "en": "Chief Warrant Officer",
         "fr": "Adjudant-chef"
@@ -329,7 +329,7 @@
     },
     {
       "level": 8,
-      "element": ["RCN"],
+      "commands": ["RCN"],
       "title": {
         "en": "Chief Petty Officer 1st class",
         "fr": "Premier maître de 1re classe"
@@ -342,7 +342,7 @@
     },
     {
       "level": 7,
-      "element": ["CA", "RCAF"],
+      "commands": ["CA", "RCAF"],
       "title": {
         "en": "Master Warrant Officer",
         "fr": "Adjudant-maître"
@@ -355,7 +355,7 @@
     },
     {
       "level": 7,
-      "element": ["RCN"],
+      "commands": ["RCN"],
       "title": {
         "en": "Chief Petty Officer 2nd class",
         "fr": "Premier maître de 2e classe"
@@ -368,7 +368,7 @@
     },
     {
       "level": 6,
-      "element": ["CA", "RCAF"],
+      "commands": ["CA", "RCAF"],
       "title": {
         "en": "Warrant Officer",
         "fr": "Adjudant"
@@ -381,7 +381,7 @@
     },
     {
       "level": 6,
-      "element": ["RCN"],
+      "commands": ["RCN"],
       "title": {
         "en": "Petty Officer 1st class",
         "fr": "Maître de 1re classe"
@@ -394,7 +394,7 @@
     },
     {
       "level": 5,
-      "element": ["CA", "RCAF"],
+      "commands": ["CA", "RCAF"],
       "title": {
         "en": "Sergeant",
         "fr": "Sergent"
@@ -407,7 +407,7 @@
     },
     {
       "level": 5,
-      "element": ["RCN"],
+      "commands": ["RCN"],
       "title": {
         "en": "Petty Officer 2nd class",
         "fr": "Maître de 2e classe"
@@ -420,7 +420,7 @@
     },
     {
       "level": 4,
-      "element": ["CA", "RCAF"],
+      "commands": ["CA", "RCAF"],
       "title": {
         "en": "Master Corporal",
         "fr": "Caporal-chef"
@@ -433,7 +433,7 @@
     },
     {
       "level": 4,
-      "element": ["RCN"],
+      "commands": ["RCN"],
       "title": {
         "en": "Master Sailor",
         "fr": "Matelot-chef"
@@ -446,7 +446,7 @@
     },
     {
       "level": 3,
-      "element": ["CA", "RCAF"],
+      "commands": ["CA", "RCAF"],
       "title": {
         "en": "Corporal",
         "fr": "Caporal"
@@ -459,7 +459,7 @@
     },
     {
       "level": 3,
-      "element": ["RCN"],
+      "commands": ["RCN"],
       "title": {
         "en": "Sailor 1st Class",
         "fr": "Matelot de 1re classe"
@@ -472,7 +472,7 @@
     },
     {
       "level": 2,
-      "element": ["CA"],
+      "commands": ["CA"],
       "title": {
         "en": "Private (Trained)",
         "fr": "Soldat (formé)"
@@ -485,7 +485,7 @@
     },
     {
       "level": 2,
-      "element": ["RCAF"],
+      "commands": ["RCAF"],
       "title": {
         "en": "Aviator (Trained)",
         "fr": "Aviateur (formé)"
@@ -498,7 +498,7 @@
     },
     {
       "level": 2,
-      "element": ["RCN"],
+      "commands": ["RCN"],
       "title": {
         "en": "Sailor 2nd Class",
         "fr": "Matelot de 2e classe"
@@ -511,7 +511,7 @@
     },
     {
       "level": 1,
-      "element": ["CA"],
+      "commands": ["CA"],
       "title": {
         "en": "Private (Basic)",
         "fr": "Soldat (confirmé)"
@@ -524,7 +524,7 @@
     },
     {
       "level": 1,
-      "element": ["RCAF"],
+      "commands": ["RCAF"],
       "title": {
         "en": "Aviator (Basic)",
         "fr": "Aviateur (confirmé)"
@@ -537,7 +537,7 @@
     },
     {
       "level": 1,
-      "element": ["RCN"],
+      "commands": ["RCN"],
       "title": {
         "en": "Sailor 3rd Class",
         "fr": "Matelot de 3e classe"

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import ranksJSON from "./caf-ranks.json";
 
 export type BilingualString = { en: string; fr: string };
 
-export type CAFElement = "CA" | "RCAF" | "RCN";
+export type Command = "CA" | "RCAF" | "RCN";
 
 export type RankCategory =
   | "FlagOfficer"
@@ -13,7 +13,7 @@ export type RankCategory =
   | "JuniorNCM";
 
 export type RankMeta = {
-  element: {
+  command: {
     CA: BilingualString;
     RCAF: BilingualString;
     RCN: BilingualString;
@@ -30,7 +30,7 @@ export type RankMeta = {
 
 export type Rank = {
   level: number;
-  element: CAFElement[];
+  commands: Command[];
   title: BilingualString;
   abbreviation: BilingualString;
   category: RankCategory;
@@ -38,25 +38,22 @@ export type Rank = {
 };
 
 export const rankMeta: RankMeta = {
-  element: ranksJSON.element,
+  command: ranksJSON.command,
   category: ranksJSON.category,
 };
 
 export const allRanks: Rank[] = ranksJSON.allRanks.map((rank) => ({
   ...rank,
-  element: rank.element as CAFElement[],
+  commands: rank.commands as Command[],
   category: rank.category as RankCategory,
   getCategoryName: function () {
     return rankMeta.category[this.category];
   },
 }));
 
-export function filterRanksByElement(
-  ranks: Rank[],
-  cafElement: CAFElement
-): Rank[] {
+export function filterRanksByElement(ranks: Rank[], command: Command): Rank[] {
   return ranks.filter((rank) => {
-    return rank.element.filter((element) => element === cafElement).length > 0;
+    return rank.commands.filter((_command) => _command === command).length > 0;
   });
 }
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -7,7 +7,7 @@ import {
   filterRanksByCategory,
   filterRanksByElement,
   RankCategory,
-  CAFElement,
+  Command,
 } from "../src/main";
 
 describe("test allRanks", () => {
@@ -25,9 +25,9 @@ describe.each(allRanks)(
       expect(rank.level).toBeLessThanOrEqual(19);
     });
 
-    test("element property contains a valid CAF element", () => {
-      expect(rank).toHaveProperty("element");
-      expect(rank.element).toContainAnyOf(["CA", "RCAF", "RCN"]);
+    test("commands property contains a valid command value", () => {
+      expect(rank).toHaveProperty("commands");
+      expect(rank.commands).toContainAnyOf(["CA", "RCAF", "RCN"]);
     });
 
     test("title property is bilingual string", () => {
@@ -94,7 +94,7 @@ describe("test filterRanksByElement()", () => {
     ["RCAF", 19],
     ["RCN", 19],
   ])("%s element has %i items", (element, expected) => {
-    expect(filterRanksByElement(allRanks, element as CAFElement)).toHaveLength(
+    expect(filterRanksByElement(allRanks, element as Command)).toHaveLength(
       expected
     );
   });


### PR DESCRIPTION
Changed type `CAFElement` to type `Command` and used `commands` instead of `element` as the property name. This PR fixes #11.